### PR TITLE
feat: implement structural design disclosure check (IBC 1603.1)

### DIFF
--- a/src/aeclib/us/egress/generic.py
+++ b/src/aeclib/us/egress/generic.py
@@ -51,12 +51,11 @@ def validate_minimum_egress_ceiling_height(
     logger.info("NOTE: [Door Height] exception is not currently considered.")
     logger.info("NOTE: [Ramp Headroom] exception is not currently considered.")
 
-    # [Parking Garages] exception: defer to Section 406.2.2
+    # Parking Garages exception
     if room_type == RoomType.PARKING_GARAGE:
         return validate_garage_clear_height(clear_height_inches=ceiling_height_inches)
 
-    # [Residential Unit Corridors] exception: defer to Chapter 12 (Interior)
-    # The code allows a reduction to 7'0" for corridors in Group R
+    # Residential Unit Corridors exception
     if (
         room_type == RoomType.CORRIDOR
         and occupancy_classification == OccupancyClassification.GROUP_R

--- a/src/aeclib/us/garage/generic.py
+++ b/src/aeclib/us/garage/generic.py
@@ -21,7 +21,7 @@ def validate_garage_clear_height(
     Returns:
         ComplianceResult. (PASS, FAIL, NOT_APPLICABLE)
     """
-    logger.info("Checking Section 406.2.2 parking garage clear height...")
+    logger.info("Checking parking garage clear height...")
 
     # Standard requirement: 7 feet 0 inches (84")
     threshold = MINIMUM_CEILING_HEIGHT_SERVICE_INCHES

--- a/src/aeclib/us/interior/generic.py
+++ b/src/aeclib/us/interior/generic.py
@@ -38,7 +38,7 @@ def validate_minimum_ceiling_height(
     Returns:
         ComplianceResult. (PASS, FAIL, NOT_APPLICABLE)
     """
-    logger.info(f"Checking Section 1208.2 minimum ceiling height for {room_type}...")
+    logger.info(f"Checking minimum ceiling height for {room_type}...")
 
     # Explicit Out-of-Scope handling
     if room_type in {RoomType.ATTIC, RoomType.CRAWL_SPACE}:

--- a/src/aeclib/us/structural/__init__.py
+++ b/src/aeclib/us/structural/__init__.py
@@ -1,0 +1,21 @@
+from .disclosure import (
+    validate_earthquake_design_disclosure,
+    validate_floor_live_load_disclosure,
+    validate_geotechnical_disclosure,
+    validate_rain_load_disclosure,
+    validate_roof_live_load_disclosure,
+    validate_snow_load_disclosure,
+    validate_structural_design_disclosure,
+    validate_wind_design_disclosure,
+)
+
+__all__ = [
+    "validate_earthquake_design_disclosure",
+    "validate_floor_live_load_disclosure",
+    "validate_geotechnical_disclosure",
+    "validate_rain_load_disclosure",
+    "validate_roof_live_load_disclosure",
+    "validate_snow_load_disclosure",
+    "validate_structural_design_disclosure",
+    "validate_wind_design_disclosure",
+]

--- a/src/aeclib/us/structural/disclosure.py
+++ b/src/aeclib/us/structural/disclosure.py
@@ -1,0 +1,339 @@
+import logging
+from typing import Any, Optional
+
+from aeclib.core import (
+    ComplianceResult,
+    ComplianceStatus,
+)
+
+logger = logging.getLogger("aeclib")
+
+
+def validate_floor_live_load_disclosure(
+    uniformly_distributed_floor_live_load: Optional[float] = None,
+    concentrated_floor_live_load: Optional[float] = None,
+    impact_floor_live_load: Optional[float] = None,
+    is_live_load_reduction_applied: bool = False,
+    **_kwargs: Any,
+) -> ComplianceResult:
+    """
+    Validates disclosure of floor live load data.
+
+    Applicable to:
+    - IBC 2024 Section 1603.1.1
+
+    Args:
+        uniformly_distributed_floor_live_load: Distributed floor live load (psf).
+        concentrated_floor_live_load: Concentrated floor live load (lbs).
+        impact_floor_live_load: Impact floor live load (lbs).
+        is_live_load_reduction_applied: True if reduction was used.
+        **_kwargs: Sink for unused structural facts.
+
+    Returns:
+        ComplianceResult. (PASS, FAIL, NOT_APPLICABLE)
+    """
+    logger.info("Checking [Floor Live Load Disclosure]...")
+
+    missing = []
+    if uniformly_distributed_floor_live_load is None:
+        missing.append("uniformly_distributed_floor_live_load")
+    if concentrated_floor_live_load is None:
+        missing.append("concentrated_floor_live_load")
+    if impact_floor_live_load is None:
+        missing.append("impact_floor_live_load")
+
+    if missing:
+        message = (
+            f"[FAIL] Missing required floor live load disclosure: {', '.join(missing)}."
+        )
+        return ComplianceResult(status=ComplianceStatus.FAIL, message=message)
+
+    return ComplianceResult(status=ComplianceStatus.PASS)
+
+
+def validate_roof_live_load_disclosure(
+    roof_live_load_psf: Optional[float] = None,
+    **_kwargs: Any,
+) -> ComplianceResult:
+    """
+    Validates disclosure of roof live load data.
+
+    Applicable to:
+    - IBC 2024 Section 1603.1.2
+
+    Args:
+        roof_live_load_psf: Roof live load (psf).
+        **_kwargs: Sink for unused structural facts.
+
+    Returns:
+        ComplianceResult. (PASS, FAIL, NOT_APPLICABLE)
+    """
+    logger.info("Checking [Roof Live Load Disclosure]...")
+
+    if roof_live_load_psf is None:
+        return ComplianceResult(
+            status=ComplianceStatus.FAIL,
+            message="[FAIL] roof_live_load_psf must be disclosed.",
+        )
+
+    return ComplianceResult(status=ComplianceStatus.PASS)
+
+
+def validate_snow_load_disclosure(
+    ground_snow_load_psf: Optional[float] = None,
+    flat_roof_snow_load_psf: Optional[float] = None,
+    snow_exposure_factor: Optional[float] = None,
+    snow_importance_factor: Optional[float] = None,
+    snow_thermal_factor: Optional[float] = None,
+    snow_drift_factor: Optional[float] = None,
+    **_kwargs: Any,
+) -> ComplianceResult:
+    """
+    Validates disclosure of roof snow load data.
+
+    Applicable to:
+    - IBC 2024 Section 1603.1.3
+
+    Args:
+        ground_snow_load_psf: Ground snow load (psf).
+        flat_roof_snow_load_psf: Flat-roof snow load (psf).
+        snow_exposure_factor: Snow exposure factor (Ce).
+        snow_importance_factor: Snow load importance factor (I).
+        snow_thermal_factor: Thermal factor (Ct).
+        snow_drift_factor: Drift exposure factor (D).
+        **_kwargs: Sink for unused structural facts.
+
+    Returns:
+        ComplianceResult. (PASS, FAIL, NOT_APPLICABLE)
+    """
+    logger.info("Checking [Snow Load Disclosure]...")
+
+    if ground_snow_load_psf is None:
+        return ComplianceResult(
+            status=ComplianceStatus.FAIL,
+            message="[FAIL] ground_snow_load_psf must be disclosed.",
+        )
+
+    # Conditional requirement: If Pg > 10 psf, extra data points are required.
+    if ground_snow_load_psf > 10.0:
+        missing = []
+        if flat_roof_snow_load_psf is None:
+            missing.append("flat_roof_snow_load_psf")
+        if snow_exposure_factor is None:
+            missing.append("snow_exposure_factor")
+        if snow_importance_factor is None:
+            missing.append("snow_importance_factor")
+        if snow_thermal_factor is None:
+            missing.append("snow_thermal_factor")
+        if snow_drift_factor is None:
+            missing.append("snow_drift_factor")
+
+        if missing:
+            return ComplianceResult(
+                status=ComplianceStatus.FAIL,
+                message=(
+                    f"[FAIL] Ground snow load exceeds 10 psf. "
+                    f"Missing required disclosure: {', '.join(missing)}."
+                ),
+            )
+
+    return ComplianceResult(status=ComplianceStatus.PASS)
+
+
+def validate_wind_design_disclosure(
+    basic_wind_speed_mph: Optional[float] = None,
+    wind_risk_category: Optional[str] = None,
+    wind_exposure_category: Optional[str] = None,
+    **_kwargs: Any,
+) -> ComplianceResult:
+    """
+    Validates baseline disclosure of wind design data.
+
+    Applicable to:
+    - IBC 2024 Section 1603.1.4
+
+    Args:
+        basic_wind_speed_mph: Basic wind speed (mph).
+        wind_risk_category: Risk category (e.g., 'I', 'II').
+        wind_exposure_category: Wind exposure (e.g., 'B', 'C').
+        **_kwargs: Sink for unused structural facts.
+
+    Returns:
+        ComplianceResult. (PASS, FAIL, NOT_APPLICABLE)
+    """
+    logger.info("Checking [Wind Design Disclosure]...")
+
+    missing = []
+    if basic_wind_speed_mph is None:
+        missing.append("basic_wind_speed_mph")
+    if wind_risk_category is None:
+        missing.append("wind_risk_category")
+    if wind_exposure_category is None:
+        missing.append("wind_exposure_category")
+
+    if missing:
+        return ComplianceResult(
+            status=ComplianceStatus.FAIL,
+            message=(
+                f"[FAIL] Missing required wind design disclosure: {', '.join(missing)}."
+            ),
+        )
+
+    # TODO: Implement complex tornado and component/cladding pressure disclosures.
+    return ComplianceResult(status=ComplianceStatus.PASS)
+
+
+def validate_earthquake_design_disclosure(
+    seismic_risk_category: Optional[str] = None,
+    seismic_importance_factor: Optional[float] = None,
+    seismic_design_category: Optional[str] = None,
+    site_class: Optional[str] = None,
+    **_kwargs: Any,
+) -> ComplianceResult:
+    """
+    Validates baseline disclosure of earthquake design data.
+
+    Applicable to:
+    - IBC 2024 Section 1603.1.5
+
+    Args:
+        seismic_risk_category: Risk category.
+        seismic_importance_factor: Importance factor (Ie).
+        seismic_design_category: Design category (SDC).
+        site_class: Soil site class (e.g., 'D').
+        **_kwargs: Sink for unused structural facts.
+
+    Returns:
+        ComplianceResult. (PASS, FAIL, NOT_APPLICABLE)
+    """
+    logger.info("Checking [Earthquake Design Disclosure]...")
+
+    missing = []
+    if seismic_risk_category is None:
+        missing.append("seismic_risk_category")
+    if seismic_importance_factor is None:
+        missing.append("seismic_importance_factor")
+    if seismic_design_category is None:
+        missing.append("seismic_design_category")
+    if site_class is None:
+        missing.append("site_class")
+
+    if missing:
+        return ComplianceResult(
+            status=ComplianceStatus.FAIL,
+            message=(
+                f"[FAIL] Missing required seismic disclosure: {', '.join(missing)}."
+            ),
+        )
+
+    # TODO: Implement spectral acceleration, shear, and response coefficients.
+    return ComplianceResult(status=ComplianceStatus.PASS)
+
+
+def validate_geotechnical_disclosure(
+    design_load_bearing_value_psf: Optional[float] = None,
+    **_kwargs: Any,
+) -> ComplianceResult:
+    """
+    Validates disclosure of geotechnical soil data.
+
+    Applicable to:
+    - IBC 2024 Section 1603.1.6
+
+    Args:
+        design_load_bearing_value_psf: Design load-bearing value of soils (psf).
+        **_kwargs: Sink for unused structural facts.
+
+    Returns:
+        ComplianceResult. (PASS, FAIL, NOT_APPLICABLE)
+    """
+    logger.info("Checking [Geotechnical Disclosure]...")
+
+    if design_load_bearing_value_psf is None:
+        return ComplianceResult(
+            status=ComplianceStatus.FAIL,
+            message="[FAIL] design_load_bearing_value_psf must be disclosed.",
+        )
+
+    return ComplianceResult(status=ComplianceStatus.PASS)
+
+
+def validate_rain_load_disclosure(
+    design_rainfall_intensity_iph: Optional[float] = None,
+    is_drainage_shown: bool = False,
+    **_kwargs: Any,
+) -> ComplianceResult:
+    """
+    Validates disclosure of roof rain load data.
+
+    Applicable to:
+    - IBC 2024 Section 1603.1.9
+
+    Args:
+        design_rainfall_intensity_iph: Design rainfall intensity (in/hr).
+        is_drainage_shown: True if drain/scupper locations are shown.
+        **_kwargs: Sink for unused structural facts.
+
+    Returns:
+        ComplianceResult. (PASS, FAIL, NOT_APPLICABLE)
+    """
+    logger.info("Checking [Rain Load Disclosure]...")
+
+    if design_rainfall_intensity_iph is None:
+        return ComplianceResult(
+            status=ComplianceStatus.FAIL,
+            message="[FAIL] design_rainfall_intensity_iph must be disclosed.",
+        )
+
+    if not is_drainage_shown:
+        return ComplianceResult(
+            status=ComplianceStatus.FAIL,
+            message="[FAIL] is_drainage_shown must be True on documents.",
+        )
+
+    return ComplianceResult(status=ComplianceStatus.PASS)
+
+
+def validate_structural_design_disclosure(
+    **structural_facts: Any,
+) -> ComplianceResult:
+    """
+    Validates completeness of structural design information in documents.
+
+    Applicable to:
+    - IBC 2024 Section 1603.1
+
+    Args:
+        **structural_facts: Arbitrary keyword arguments containing structural facts.
+                           Expected keys must match aeclib argument names.
+
+    Returns:
+        ComplianceResult. (PASS, FAIL, NOT_APPLICABLE)
+    """
+    logger.info("Checking [Structural Design Disclosure] completeness...")
+
+    # We call our atomic sub-checks. Each check returns a ComplianceResult.
+    # Due to the **_kwargs sinks, we can safely pass all facts to every check.
+    checks = [
+        validate_floor_live_load_disclosure(**structural_facts),
+        validate_roof_live_load_disclosure(**structural_facts),
+        validate_snow_load_disclosure(**structural_facts),
+        validate_wind_design_disclosure(**structural_facts),
+        validate_earthquake_design_disclosure(**structural_facts),
+        validate_geotechnical_disclosure(**structural_facts),
+        validate_rain_load_disclosure(**structural_facts),
+    ]
+
+    # Collect all failures
+    failures = [r.message for r in checks if not r]
+
+    if failures:
+        return ComplianceResult(
+            status=ComplianceStatus.FAIL,
+            message=f"[FAIL] Structural disclosure incomplete: {'; '.join(failures)}",
+        )
+
+    # TODO: Add checks for 1603.1.7 (Flood) and 1603.1.8 (Special Loads).
+    logger.info("NOTE: [Flood] and [Special Load] disclosures are not yet implemented.")
+
+    return ComplianceResult(status=ComplianceStatus.PASS)

--- a/tests/us/structural/test_disclosure.py
+++ b/tests/us/structural/test_disclosure.py
@@ -1,0 +1,145 @@
+from aeclib.core import ComplianceStatus
+from aeclib.us.structural import (
+    validate_earthquake_design_disclosure,
+    validate_floor_live_load_disclosure,
+    validate_geotechnical_disclosure,
+    validate_rain_load_disclosure,
+    validate_roof_live_load_disclosure,
+    validate_snow_load_disclosure,
+    validate_structural_design_disclosure,
+    validate_wind_design_disclosure,
+)
+
+
+def test_validate_floor_live_load_disclosure():
+    # [Floor Live Load Disclosure]: Missing concentrated load -> FAIL
+    assert (
+        validate_floor_live_load_disclosure(
+            uniformly_distributed_floor_live_load=50.0
+        ).status
+        == ComplianceStatus.FAIL
+    )
+
+    # [Floor Live Load Disclosure]: All present -> PASS
+    assert (
+        validate_floor_live_load_disclosure(
+            uniformly_distributed_floor_live_load=50.0,
+            concentrated_floor_live_load=2000.0,
+            impact_floor_live_load=0.0,
+        ).status
+        == ComplianceStatus.PASS
+    )
+
+
+def test_validate_roof_live_load_disclosure():
+    # [Roof Live Load Disclosure]: Missing -> FAIL
+    assert (
+        validate_roof_live_load_disclosure(roof_live_load_psf=None).status
+        == ComplianceStatus.FAIL
+    )
+    # [Roof Live Load Disclosure]: Present -> PASS
+    assert (
+        validate_roof_live_load_disclosure(roof_live_load_psf=20.0).status
+        == ComplianceStatus.PASS
+    )
+
+
+def test_validate_snow_load_disclosure():
+    # [Snow Load Disclosure]: ground_snow_load_psf missing -> FAIL
+    assert (
+        validate_snow_load_disclosure(ground_snow_load_psf=None).status
+        == ComplianceStatus.FAIL
+    )
+    # [Snow Load Disclosure]: Low snow -> PASS
+    assert (
+        validate_snow_load_disclosure(ground_snow_load_psf=5.0).status
+        == ComplianceStatus.PASS
+    )
+
+
+def test_validate_wind_design_disclosure():
+    # [Wind Disclosure]: Missing speed -> FAIL
+    assert (
+        validate_wind_design_disclosure(wind_risk_category="II").status
+        == ComplianceStatus.FAIL
+    )
+    # [Wind Disclosure]: All present -> PASS
+    assert (
+        validate_wind_design_disclosure(
+            basic_wind_speed_mph=115.0,
+            wind_risk_category="II",
+            wind_exposure_category="B",
+        ).status
+        == ComplianceStatus.PASS
+    )
+
+
+def test_validate_earthquake_design_disclosure():
+    # [Seismic Disclosure]: All present -> PASS
+    assert (
+        validate_earthquake_design_disclosure(
+            seismic_risk_category="II",
+            seismic_importance_factor=1.0,
+            seismic_design_category="D",
+            site_class="D",
+        ).status
+        == ComplianceStatus.PASS
+    )
+
+
+def test_validate_geotechnical_disclosure():
+    # [Geotech Disclosure]: All present -> PASS
+    assert (
+        validate_geotechnical_disclosure(design_load_bearing_value_psf=1500.0).status
+        == ComplianceStatus.PASS
+    )
+
+
+def test_validate_rain_load_disclosure():
+    # [Rain Disclosure]: Missing drainage info -> FAIL
+    assert (
+        validate_rain_load_disclosure(
+            design_rainfall_intensity_iph=2.0, is_drainage_shown=False
+        ).status
+        == ComplianceStatus.FAIL
+    )
+
+
+def test_validate_structural_design_disclosure_aggregate():
+    # [Aggregate Disclosure]: Full set of clean data -> PASS
+    full_data = {
+        "uniformly_distributed_floor_live_load": 50.0,
+        "concentrated_floor_live_load": 2000.0,
+        "impact_floor_live_load": 0.0,
+        "roof_live_load_psf": 20.0,
+        "ground_snow_load_psf": 5.0,
+        "basic_wind_speed_mph": 115.0,
+        "wind_risk_category": "II",
+        "wind_exposure_category": "B",
+        "seismic_risk_category": "II",
+        "seismic_importance_factor": 1.0,
+        "seismic_design_category": "D",
+        "site_class": "D",
+        "design_load_bearing_value_psf": 1500.0,
+        "design_rainfall_intensity_iph": 3.0,
+        "is_drainage_shown": True,
+    }
+
+    result = validate_structural_design_disclosure(**full_data)
+    assert result.status == ComplianceStatus.PASS
+
+
+def test_validate_structural_design_disclosure_incomplete():
+    # [Aggregate Disclosure]: Missing one required field (geotech) -> FAIL
+    incomplete_data = {
+        "uniformly_distributed_floor_live_load": 50.0,
+        "concentrated_floor_live_load": 2000.0,
+        "impact_floor_live_load": 0.0,
+        "roof_live_load_psf": 20.0,
+        "ground_snow_load_psf": 5.0,
+        # geotechnical is missing
+    }
+
+    result = validate_structural_design_disclosure(**incomplete_data)
+    assert result.status == ComplianceStatus.FAIL
+    assert "design_load_bearing_value_psf" in result.message


### PR DESCRIPTION
## How it is intended to be used:

A structural engineer or BIM manager can "dump" their project summary (from a Revit model, calculation script, or scraped General Notes page) into a JSON object. Then, they can run `validate_structural_design_disclosure(json_object)`, to see what info they are missing.


1. Atomic Verification: Individual functions (e.g., validate_snow_load_disclosure) "know" the legal triggers for extra data (like the 10 psf snow threshold) and only demand what is legally required for that project’s specific state.
2. Aggregate Quality Control: The top-level validate_structural_design_disclosure aggregates all sub-checks, providing a comprehensive report of exactly which legal disclosures are missing from the design package.