### PR TITLE
Implement IBC Chapter 6 Types of Construction

### DIFF
--- a/src/aeclib/us/common/construction_type.py
+++ b/src/aeclib/us/common/construction_type.py
@@ -1,0 +1,21 @@
+from enum import Enum
+
+
+class ConstructionType(str, Enum):
+    """
+    IBC 2024 Chapter 6 Construction Types.
+    Defines the fire-resistance requirements for building elements.
+    """
+
+    TYPE_I_A = "I-A"
+    TYPE_I_B = "I-B"
+    TYPE_II_A = "II-A"
+    TYPE_II_B = "II-B"
+    TYPE_III_A = "III-A"
+    TYPE_III_B = "III-B"
+    TYPE_IV_A = "IV-A"
+    TYPE_IV_B = "IV-B"
+    TYPE_IV_C = "IV-C"
+    TYPE_IV_HT = "IV-HT"
+    TYPE_V_A = "V-A"
+    TYPE_V_B = "V-B"

--- a/src/aeclib/us/common/elements.py
+++ b/src/aeclib/us/common/elements.py
@@ -1,0 +1,24 @@
+from enum import Enum
+
+
+class BuildingElementCategory(str, Enum):
+    """
+    IBC 2024 Building Element Categories.
+    Currently used for determining fire-resistance requirements (Table 601) and material exceptions (Section 603).
+    TODO: Need to evaluate if this enum will be compatible with other use cases.
+    """
+
+    # Structural Elements (Table 601)
+    PRIMARY_STRUCTURAL_FRAME = "primary_structural_frame"
+    BEARING_WALL_EXTERIOR = "bearing_wall_exterior"
+    BEARING_WALL_INTERIOR = "bearing_wall_interior"
+    NONBEARING_WALL_EXTERIOR = "nonbearing_wall_exterior"
+    NONBEARING_WALL_INTERIOR = "nonbearing_wall_interior"
+    FLOOR_CONSTRUCTION = "floor_construction"
+    ROOF_CONSTRUCTION = "roof_construction"
+
+    # Material exceptions (Section 603)
+    THERMAL_INSULATION = "thermal_insulation"
+    ROOF_COVERING = "roof_covering"
+    INTERIOR_FINISH = "interior_finish"
+    MILLWORK = "millwork"

--- a/src/aeclib/us/fire/__init__.py
+++ b/src/aeclib/us/fire/__init__.py
@@ -1,0 +1,3 @@
+"""
+Fire and smoke protection logic, handling Chapter 6 and Chapter 7 provisions.
+"""

--- a/src/aeclib/us/fire/materials.py
+++ b/src/aeclib/us/fire/materials.py
@@ -1,0 +1,11 @@
+"""
+Material-specific fire safety logic.
+"""
+
+# TODO: Implement Section 603 (Combustible Material in Types I and II Construction).
+# Implementation of Section 603 is currently deferred.
+# It contains a highly granular list of exceptions (e.g., thermal insulation, millwork,
+# roof coverings) and delegates to many other chapters (like Chapter 8 for interior
+# finishes, Chapter 15 for roofs, and Chapter 26 for plastics).
+# Future implementations will require robust element-level metadata from the BIM model
+# (e.g., flame spread indices, material taxonomy) to validate these exceptions.

--- a/src/aeclib/us/fire/ratings.py
+++ b/src/aeclib/us/fire/ratings.py
@@ -1,0 +1,128 @@
+from typing import Union
+
+from aeclib.us.common.construction_type import ConstructionType
+from aeclib.us.common.elements import BuildingElementCategory
+
+# Maps (Element, ConstructionType) -> Rating
+# Using floats for hours (e.g. 1.5). 'HT' for Heavy Timber.
+REQUIRED_FIRE_RATINGS_BY_ELEMENT = {
+    BuildingElementCategory.PRIMARY_STRUCTURAL_FRAME: {
+        ConstructionType.TYPE_I_A: 3.0,
+        ConstructionType.TYPE_I_B: 2.0,
+        ConstructionType.TYPE_II_A: 1.0,
+        ConstructionType.TYPE_II_B: 0.0,
+        ConstructionType.TYPE_III_A: 1.0,
+        ConstructionType.TYPE_III_B: 0.0,
+        ConstructionType.TYPE_IV_A: 3.0,
+        ConstructionType.TYPE_IV_B: 2.0,
+        ConstructionType.TYPE_IV_C: 2.0,
+        ConstructionType.TYPE_IV_HT: "HT",
+        ConstructionType.TYPE_V_A: 1.0,
+        ConstructionType.TYPE_V_B: 0.0,
+    },
+    BuildingElementCategory.BEARING_WALL_EXTERIOR: {
+        ConstructionType.TYPE_I_A: 3.0,
+        ConstructionType.TYPE_I_B: 2.0,
+        ConstructionType.TYPE_II_A: 1.0,
+        ConstructionType.TYPE_II_B: 0.0,
+        ConstructionType.TYPE_III_A: 2.0,
+        ConstructionType.TYPE_III_B: 2.0,
+        ConstructionType.TYPE_IV_A: 3.0,
+        ConstructionType.TYPE_IV_B: 2.0,
+        ConstructionType.TYPE_IV_C: 2.0,
+        ConstructionType.TYPE_IV_HT: 2.0,
+        ConstructionType.TYPE_V_A: 1.0,
+        ConstructionType.TYPE_V_B: 0.0,
+    },
+    BuildingElementCategory.BEARING_WALL_INTERIOR: {
+        ConstructionType.TYPE_I_A: 3.0,
+        ConstructionType.TYPE_I_B: 2.0,
+        ConstructionType.TYPE_II_A: 1.0,
+        ConstructionType.TYPE_II_B: 0.0,
+        ConstructionType.TYPE_III_A: 1.0,
+        ConstructionType.TYPE_III_B: 0.0,
+        ConstructionType.TYPE_IV_A: 3.0,
+        ConstructionType.TYPE_IV_B: 2.0,
+        ConstructionType.TYPE_IV_C: 2.0,
+        ConstructionType.TYPE_IV_HT: "1/HT",
+        ConstructionType.TYPE_V_A: 1.0,
+        ConstructionType.TYPE_V_B: 0.0,
+    },
+    BuildingElementCategory.NONBEARING_WALL_INTERIOR: {ct: 0.0 for ct in ConstructionType},
+    BuildingElementCategory.FLOOR_CONSTRUCTION: {
+        ConstructionType.TYPE_I_A: 2.0,
+        ConstructionType.TYPE_I_B: 2.0,
+        ConstructionType.TYPE_II_A: 1.0,
+        ConstructionType.TYPE_II_B: 0.0,
+        ConstructionType.TYPE_III_A: 1.0,
+        ConstructionType.TYPE_III_B: 0.0,
+        ConstructionType.TYPE_IV_A: 2.0,
+        ConstructionType.TYPE_IV_B: 2.0,
+        ConstructionType.TYPE_IV_C: 2.0,
+        ConstructionType.TYPE_IV_HT: "HT",
+        ConstructionType.TYPE_V_A: 1.0,
+        ConstructionType.TYPE_V_B: 0.0,
+    },
+    BuildingElementCategory.ROOF_CONSTRUCTION: {
+        ConstructionType.TYPE_I_A: 1.5,
+        ConstructionType.TYPE_I_B: 1.0,
+        ConstructionType.TYPE_II_A: 1.0,
+        ConstructionType.TYPE_II_B: 0.0,
+        ConstructionType.TYPE_III_A: 1.0,
+        ConstructionType.TYPE_III_B: 0.0,
+        ConstructionType.TYPE_IV_A: 1.5,
+        ConstructionType.TYPE_IV_B: 1.0,
+        ConstructionType.TYPE_IV_C: 1.0,
+        ConstructionType.TYPE_IV_HT: "HT",
+        ConstructionType.TYPE_V_A: 1.0,
+        ConstructionType.TYPE_V_B: 0.0,
+    },
+}
+
+
+def get_required_fire_resistance_rating(
+    construction_type: ConstructionType,
+    element_category: BuildingElementCategory,
+    is_supporting_roof_only: bool = False,
+) -> Union[float, str]:
+    """
+    Returns the required fire-resistance rating in hours.
+
+    Applicable to:
+    - IBC 2024 Section 602.1
+    - IBC 2024 Table 601
+
+    Values are typically floats (e.g. 1.0, 1.5).
+    For Heavy Timber, returns strings like 'HT' or '1/HT'.
+
+    Args:
+        construction_type: The building construction type.
+        element_category: The structural element category.
+        is_supporting_roof_only: True if the element only supports a roof.
+
+    Returns:
+        Union[float, str].
+    """
+
+    # Exterior nonbearing walls are dictated by Table 705.5 based on fire separation distance.
+    if element_category == BuildingElementCategory.NONBEARING_WALL_EXTERIOR:
+        raise ValueError(
+            "Exterior nonbearing wall ratings are based on fire separation distance per Table 705.5, not Table 601."
+        )
+
+    # Some categories (like Insulation) don't have ratings in Table 601
+    if element_category not in REQUIRED_FIRE_RATINGS_BY_ELEMENT:
+        raise ValueError(f"Category {element_category} does not have a Table 601 rating.")
+
+    base_rating = REQUIRED_FIRE_RATINGS_BY_ELEMENT[element_category][construction_type]
+
+    # Footnote a: Roof supports can be reduced by 1 hour where supporting a roof only.
+    if is_supporting_roof_only and isinstance(base_rating, float):
+        if element_category in [
+            BuildingElementCategory.PRIMARY_STRUCTURAL_FRAME,
+            BuildingElementCategory.BEARING_WALL_EXTERIOR,
+            BuildingElementCategory.BEARING_WALL_INTERIOR,
+        ]:
+            return max(0.0, base_rating - 1.0)
+
+    return base_rating

--- a/tests/us/fire/test_ratings.py
+++ b/tests/us/fire/test_ratings.py
@@ -1,0 +1,66 @@
+import pytest
+
+from aeclib.us.common.construction_type import ConstructionType
+from aeclib.us.common.elements import BuildingElementCategory
+from aeclib.us.fire.ratings import get_required_fire_resistance_rating
+
+
+def test_primary_structural_frame_ratings():
+    # Type IA needs 3 hours
+    assert (
+        get_required_fire_resistance_rating(ConstructionType.TYPE_I_A, BuildingElementCategory.PRIMARY_STRUCTURAL_FRAME)
+        == 3.0
+    )
+
+    # Type IIB needs 0 hours
+    assert (
+        get_required_fire_resistance_rating(
+            ConstructionType.TYPE_II_B, BuildingElementCategory.PRIMARY_STRUCTURAL_FRAME
+        )
+        == 0.0
+    )
+
+    # Type IV-HT uses Heavy Timber
+    assert (
+        get_required_fire_resistance_rating(
+            ConstructionType.TYPE_IV_HT, BuildingElementCategory.PRIMARY_STRUCTURAL_FRAME
+        )
+        == "HT"
+    )
+
+
+def test_roof_support_reduction():
+    # Type IA primary frame is 3 hours, but reduced to 2 if supporting roof only
+    assert (
+        get_required_fire_resistance_rating(
+            ConstructionType.TYPE_I_A, BuildingElementCategory.PRIMARY_STRUCTURAL_FRAME, is_supporting_roof_only=True
+        )
+        == 2.0
+    )
+
+    # Type IIA bearing wall is 1 hour, reduced to 0 if supporting roof only
+    assert (
+        get_required_fire_resistance_rating(
+            ConstructionType.TYPE_II_A, BuildingElementCategory.BEARING_WALL_EXTERIOR, is_supporting_roof_only=True
+        )
+        == 0.0
+    )
+
+    # Should not reduce floor construction even if supporting roof only flag is passed (doesn't apply)
+    assert (
+        get_required_fire_resistance_rating(
+            ConstructionType.TYPE_I_A, BuildingElementCategory.FLOOR_CONSTRUCTION, is_supporting_roof_only=True
+        )
+        == 2.0
+    )
+
+
+def test_nonbearing_exterior_wall_raises_error():
+    # Nonbearing exterior walls use Table 705.5
+    with pytest.raises(ValueError):
+        get_required_fire_resistance_rating(ConstructionType.TYPE_I_A, BuildingElementCategory.NONBEARING_WALL_EXTERIOR)
+
+
+def test_unsupported_category_raises_error():
+    with pytest.raises(ValueError):
+        get_required_fire_resistance_rating(ConstructionType.TYPE_I_A, BuildingElementCategory.THERMAL_INSULATION)


### PR DESCRIPTION
- Added `ConstructionType` enum (Type I-V including Mass Timber) to `us/common/construction_type.py` based on IBC Section 602.
- Added `BuildingElementCategory` enum to `us/common/elements.py` to strongly type structural components.
- Implemented `get_required_fire_resistance_rating` in `us/fire/ratings.py` to encode the hour rating requirements matrix from IBC Table 601.
- Added roof support 1-hour reduction logic (Table 601 footnote a).
- Created `us/fire/materials.py` with deferred implementation notes for Section 603 (combustible material exceptions).
- Added comprehensive unit tests in `tests/us/fire/test_ratings.py`.